### PR TITLE
Avoid repeating injected annotations - to be compatible with code-generation libs like google-auto-value

### DIFF
--- a/src/test/resources/datadog/compiler/TestAnnotated.java
+++ b/src/test/resources/datadog/compiler/TestAnnotated.java
@@ -1,0 +1,13 @@
+package datadog.compiler;
+
+import datadog.compiler.annotations.MethodLines;
+import datadog.compiler.annotations.SourcePath;
+
+@SourcePath("the-source-path")
+public class TestAnnotated {
+
+    @MethodLines(start = 1, end = 2)
+    public void annotatedMethod() {
+        // no op
+    }
+}


### PR DESCRIPTION
# What Does This Do
Adds a check to verify that injected annotations are not present in the class or method.

# Motivation
Code-generation libraries (e.g. [Google Auto-Value](https://github.com/google/auto/tree/main/value)) might copy annotations from abstract methods to their generated concrete implementations.
That means a method might end-up having two identical  annotations - one injected, one copied by the code-generation lib.
As the injected annotations are not-repeatable, such situation would lead to compilation failure.
