### PR TITLE
Implement annotating classes, interfaces and enums with source lines data 

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ augments compiled classes with some additional data used by Datadog products.
 List of things that the plugin does:
 
 - Annotate every class with a `@SourcePath("...")` annotation that has the path to the class' source code
-- Annotate every public method with a `@MethodLines("...")` annotation that has method start and end lines (taking into account method modifiers and annotations)
+- Annotate every class, interface, enum and public method with a `@SourceLines("...")` annotation that has start and end lines (taking into account modifiers and annotations)
 
 ## Configuration
 
@@ -29,7 +29,7 @@ Add plugin-client JAR to the project's classpath:
     <dependency>
         <groupId>com.datadoghq</groupId>
         <artifactId>dd-javac-plugin-client</artifactId>
-        <version>0.2.0</version>
+        <version>0.2.2</version>
     </dependency>
 </dependencies>
 ```
@@ -49,7 +49,7 @@ Add plugin JAR to the compiler's annotation processor path and pass the plugin a
                     <annotationProcessorPath>
                         <groupId>com.datadoghq</groupId>
                         <artifactId>dd-javac-plugin</artifactId>
-                        <version>0.2.0</version>
+                        <version>0.2.2</version>
                     </annotationProcessorPath>
                 </annotationProcessorPaths>
                 <compilerArgs>
@@ -73,9 +73,9 @@ the plugin argument:
 
 ```groovy
 dependencies {
-    implementation 'com.datadoghq:dd-javac-plugin-client:0.2.0'
-    annotationProcessor 'com.datadoghq:dd-javac-plugin:0.2.0'
-    testAnnotationProcessor 'com.datadoghq:dd-javac-plugin:0.2.0'
+    implementation 'com.datadoghq:dd-javac-plugin-client:0.2.2'
+    annotationProcessor 'com.datadoghq:dd-javac-plugin:0.2.2'
+    testAnnotationProcessor 'com.datadoghq:dd-javac-plugin:0.2.2'
 }
 
 tasks.withType(JavaCompile).configureEach {
@@ -91,7 +91,7 @@ Below is an example for direct compiler invocation:
 
 ```shell
 javac \
-    -classpath dd-javac-plugin-client-0.2.1-all.jar \
+    -classpath dd-javac-plugin-client-0.2.2-all.jar \
     -Xplugin:DatadogCompilerPlugin \
     <PATH_TO_SOURCES>
 ```
@@ -103,13 +103,16 @@ To access the injected information, use `CompilerUtils` class from the `dd-javac
 ```java
 String sourcePath = CompilerUtils.getSourcePath(MyClass.class);
 
-int startLine = CompilerUtils.getStartLine(method);
-int endLine = CompilerUtils.getEndLine(method);
+int classStartLine = CompilerUtils.getStartLine(MyClass.class);
+int classEndLine = CompilerUtils.getEndLine(MyClass.class);
+
+int methodStartLine = CompilerUtils.getStartLine(method);
+int methodEndLine = CompilerUtils.getEndLine(method);
 ```
 
 ## Additional configuration
 
-Specify `disableMethodAnnotation` plugin argument if you want to disable annotating public methods.
+Specify `disableSourceLinesAnnotation` plugin argument if you want to disable annotating source lines.
 The argument can be specified in `javac` command line after the `-Xplugin` clause.
 
 ## Limitations

--- a/dd-javac-plugin-client/src/main/java/datadog/compiler/annotations/SourceLines.java
+++ b/dd-javac-plugin-client/src/main/java/datadog/compiler/annotations/SourceLines.java
@@ -5,9 +5,9 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Target({ElementType.METHOD, ElementType.CONSTRUCTOR})
+@Target({ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
-public @interface MethodLines {
+public @interface SourceLines {
     int start();
     int end();
 }

--- a/dd-javac-plugin-client/src/main/java/datadog/compiler/utils/CompilerUtils.java
+++ b/dd-javac-plugin-client/src/main/java/datadog/compiler/utils/CompilerUtils.java
@@ -1,6 +1,6 @@
 package datadog.compiler.utils;
 
-import datadog.compiler.annotations.MethodLines;
+import datadog.compiler.annotations.SourceLines;
 import datadog.compiler.annotations.SourcePath;
 import java.lang.reflect.Executable;
 
@@ -41,7 +41,7 @@ public class CompilerUtils {
      * @return Start line of the method or {@link CompilerUtils#LINE_UNKNOWN} if the line cannot be determined
      */
     public static int getStartLine(Executable executable) {
-        MethodLines methodLines = executable.getAnnotation(MethodLines.class);
+        SourceLines methodLines = executable.getAnnotation(SourceLines.class);
         return methodLines != null ? methodLines.start() : LINE_UNKNOWN;
     }
 
@@ -52,7 +52,29 @@ public class CompilerUtils {
      * @return End line of the method or {@link CompilerUtils#LINE_UNKNOWN} if the line cannot be determined
      */
     public static int getEndLine(Executable executable) {
-        MethodLines methodLines = executable.getAnnotation(MethodLines.class);
+        SourceLines methodLines = executable.getAnnotation(SourceLines.class);
         return methodLines != null ? methodLines.end() : LINE_UNKNOWN;
+    }
+
+    /**
+     * Returns start line of the provided class (class name, modifiers and annotations are taken into account).
+     *
+     * @param clazz Class
+     * @return Start line of the class or {@link CompilerUtils#LINE_UNKNOWN} if the line cannot be determined
+     */
+    public static int getStartLine(Class<?> clazz) {
+        SourceLines classLines = clazz.getAnnotation(SourceLines.class);
+        return classLines != null ? classLines.start() : LINE_UNKNOWN;
+    }
+
+    /**
+     * Returns end line of the provided class.
+     *
+     * @param clazz Class
+     * @return End line of the class or {@link CompilerUtils#LINE_UNKNOWN} if the line cannot be determined
+     */
+    public static int getEndLine(Class<?> clazz) {
+        SourceLines classLines = clazz.getAnnotation(SourceLines.class);
+        return classLines != null ? classLines.end() : LINE_UNKNOWN;
     }
 }

--- a/dd-javac-plugin-client/src/test/java/datadog/compiler/utils/CompilerUtilsTest.java
+++ b/dd-javac-plugin-client/src/test/java/datadog/compiler/utils/CompilerUtilsTest.java
@@ -1,5 +1,6 @@
 package datadog.compiler.utils;
 
+import datadog.compiler.annotations.SourceLines;
 import datadog.compiler.annotations.SourcePath;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -7,8 +8,11 @@ import org.junit.jupiter.api.Test;
 public class CompilerUtilsTest {
 
     private static final String TEST_CLASS_SOURCE_PATH = "/repo/src/package/TestClass.java";
+    private static final int TEST_CLASS_SOURCE_LINES_START = 16;
+    private static final int TEST_CLASS_SOURCE_LINES_END = 18;
 
     @SourcePath(TEST_CLASS_SOURCE_PATH)
+    @SourceLines(start = TEST_CLASS_SOURCE_LINES_START, end = TEST_CLASS_SOURCE_LINES_END)
     private static final class TestClass {
     }
 
@@ -18,4 +22,11 @@ public class CompilerUtilsTest {
         Assertions.assertEquals(TEST_CLASS_SOURCE_PATH, sourcePath);
     }
 
+    @Test
+    public void testSourceLinesExtraction() {
+        int startLine = CompilerUtils.getStartLine(TestClass.class);
+        int endLine = CompilerUtils.getEndLine(TestClass.class);
+        Assertions.assertEquals(TEST_CLASS_SOURCE_LINES_START, startLine);
+        Assertions.assertEquals(TEST_CLASS_SOURCE_LINES_END, endLine);
+    }
 }

--- a/dd-javac-plugin-client/src/test/java/datadog/compiler/utils/CompilerUtilsTest.java
+++ b/dd-javac-plugin-client/src/test/java/datadog/compiler/utils/CompilerUtilsTest.java
@@ -4,16 +4,23 @@ import datadog.compiler.annotations.SourceLines;
 import datadog.compiler.annotations.SourcePath;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import java.lang.reflect.Method;
 
 public class CompilerUtilsTest {
 
     private static final String TEST_CLASS_SOURCE_PATH = "/repo/src/package/TestClass.java";
-    private static final int TEST_CLASS_SOURCE_LINES_START = 16;
-    private static final int TEST_CLASS_SOURCE_LINES_END = 18;
+    private static final int TEST_CLASS_SOURCE_LINES_START = 19;
+    private static final int TEST_CLASS_SOURCE_LINES_END = 24;
+    private static final int TEST_METHOD_SOURCE_LINES_START = 21;
+    private static final int TEST_METHOD_SOURCE_LINES_END = 23;
 
     @SourcePath(TEST_CLASS_SOURCE_PATH)
     @SourceLines(start = TEST_CLASS_SOURCE_LINES_START, end = TEST_CLASS_SOURCE_LINES_END)
     private static final class TestClass {
+        @SourceLines(start = TEST_METHOD_SOURCE_LINES_START, end = TEST_METHOD_SOURCE_LINES_END)
+        public static void testMethod() {
+            // no op
+        }
     }
 
     @Test
@@ -23,7 +30,16 @@ public class CompilerUtilsTest {
     }
 
     @Test
-    public void testSourceLinesExtraction() {
+    public void testMethodLinesExtraction() throws Exception {
+        Method method = TestClass.class.getDeclaredMethod("testMethod");
+        int startLine = CompilerUtils.getStartLine(method);
+        int endLine = CompilerUtils.getEndLine(method);
+        Assertions.assertEquals(TEST_METHOD_SOURCE_LINES_START, startLine);
+        Assertions.assertEquals(TEST_METHOD_SOURCE_LINES_END, endLine);
+    }
+
+    @Test
+    public void testClassLinesExtraction() {
         int startLine = CompilerUtils.getStartLine(TestClass.class);
         int endLine = CompilerUtils.getEndLine(TestClass.class);
         Assertions.assertEquals(TEST_CLASS_SOURCE_LINES_START, startLine);

--- a/src/main/java/datadog/compiler/AnnotationsInjectingClassVisitor.java
+++ b/src/main/java/datadog/compiler/AnnotationsInjectingClassVisitor.java
@@ -18,52 +18,95 @@ public class AnnotationsInjectingClassVisitor extends TreeScanner<Void, Void> {
     private final TreeMaker maker;
     private final Names names;
     private final JCTree.JCAnnotation sourcePathAnnotation;
-    private final JCTree.JCExpression methodLinesAnnotationType;
-    private final boolean methodAnnotationDisabled;
+    private final JCTree.JCExpression sourceLinesAnnotationType;
+    private final boolean sourceLinesAnnotationDisabled;
     private final LineMap lineMap;
     private final EndPosTable endPositions;
 
     AnnotationsInjectingClassVisitor(TreeMaker maker,
                                      Names names,
                                      JCTree.JCAnnotation sourcePathAnnotation,
-                                     JCTree.JCExpression methodLinesAnnotationType,
-                                     boolean methodAnnotationDisabled,
+                                     JCTree.JCExpression sourceLinesAnnotationType,
+                                     boolean sourceLinesAnnotationDisabled,
                                      LineMap lineMap,
                                      EndPosTable endPositions) {
         this.maker = maker;
         this.names = names;
         this.sourcePathAnnotation = sourcePathAnnotation;
-        this.methodLinesAnnotationType = methodLinesAnnotationType;
-        this.methodAnnotationDisabled = methodAnnotationDisabled;
+        this.sourceLinesAnnotationType = sourceLinesAnnotationType;
+        this.sourceLinesAnnotationDisabled = sourceLinesAnnotationDisabled;
         this.lineMap = lineMap;
         this.endPositions = endPositions;
     }
 
     @Override
     public Void visitClass(ClassTree node, Void aVoid) {
+        boolean sourcePathDetected = false;
+        boolean sourceLinesDetected = false;
         JCTree.JCClassDecl classDeclaration = (JCTree.JCClassDecl) node;
+
         for (JCTree.JCAnnotation annotation : classDeclaration.mods.annotations) {
-            if (annotation.annotationType.toString().endsWith("SourcePath")) {
-                // The method is already annotated with @SourcePath.
+            if (annotation.annotationType.toString().endsWith("SourceLines")) {
+                // The class is already annotated with @SourceLines.
                 // This can happen, for instance, when code-generation tools are used
                 // that copy annotations from interface to class
-                return super.visitClass(node, aVoid);
+                sourceLinesDetected = true;
+            }
+            if (annotation.annotationType.toString().endsWith("SourcePath")) {
+                // The class is already annotated with @SourcePath.
+                sourcePathDetected = true;
             }
         }
 
-        if (node.getSimpleName().length() > 0) {
+        if (node.getSimpleName().length() == 0) {
+            // Anonymous
+            return super.visitClass(node, aVoid);
+        }
+
+        if (!sourcePathDetected) {
             classDeclaration.mods.annotations = classDeclaration.mods.annotations.prepend(sourcePathAnnotation);
         }
+
+        if (!sourceLinesDetected) {
+            JCTree.JCModifiers modifiers = classDeclaration.getModifiers();
+
+            int startPosition = modifiers.getStartPosition();
+            if (startPosition == Position.NOPOS) {
+                startPosition = classDeclaration.getStartPosition();
+            }
+
+            int endPosition = classDeclaration.getEndPosition(endPositions);
+            if (endPosition == Position.NOPOS) {
+                return super.visitClass(node, aVoid);
+            }
+
+            int startLine = (int) lineMap.getLineNumber(startPosition);
+            int endLine = (int) lineMap.getLineNumber(endPosition);
+
+            Name startName = names.fromString("start");
+            JCTree.JCIdent startIdent = maker.Ident(startName);
+            JCTree.JCLiteral startLiteral = maker.Literal(startLine);
+            JCTree.JCAssign startAssign = maker.Assign(startIdent, startLiteral);
+
+            Name endName = names.fromString("end");
+            JCTree.JCIdent endIdent = maker.Ident(endName);
+            JCTree.JCLiteral endLiteral = maker.Literal(endLine);
+            JCTree.JCAssign endAssign = maker.Assign(endIdent, endLiteral);
+
+            JCTree.JCAnnotation sourceLinesAnnotation = annotation(maker, sourceLinesAnnotationType, startAssign, endAssign);
+            classDeclaration.mods.annotations = classDeclaration.mods.annotations.prepend(sourceLinesAnnotation);
+        }
+
         return super.visitClass(node, aVoid);
     }
 
     public Void visitMethod(MethodTree node, Void aVoid) {
-        if (!methodAnnotationDisabled && (node instanceof JCTree.JCMethodDecl)) {
+        if (!sourceLinesAnnotationDisabled && (node instanceof JCTree.JCMethodDecl)) {
             JCTree.JCMethodDecl methodDecl = (JCTree.JCMethodDecl) node;
 
             for (JCTree.JCAnnotation annotation : methodDecl.mods.annotations) {
-                if (annotation.annotationType.toString().endsWith("MethodLines")) {
-                    // The method is already annotated with @MethodLines.
+                if (annotation.annotationType.toString().endsWith("SourceLines")) {
+                    // The method is already annotated with @SourceLines.
                     // This can happen, for instance, when code-generation tools are used
                     // that copy annotations from interface methods to class methods
                     return super.visitMethod(node, aVoid);
@@ -100,8 +143,8 @@ public class AnnotationsInjectingClassVisitor extends TreeScanner<Void, Void> {
                 JCTree.JCLiteral endLiteral = maker.Literal(endLine);
                 JCTree.JCAssign endAssign = maker.Assign(endIdent, endLiteral);
 
-                JCTree.JCAnnotation methodLinesAnnotation = annotation(maker, methodLinesAnnotationType, startAssign, endAssign);
-                methodDecl.mods.annotations = methodDecl.mods.annotations.prepend(methodLinesAnnotation);
+                JCTree.JCAnnotation sourceLinesAnnotation = annotation(maker, sourceLinesAnnotationType, startAssign, endAssign);
+                methodDecl.mods.annotations = methodDecl.mods.annotations.prepend(sourceLinesAnnotation);
             }
         }
         return super.visitMethod(node, aVoid);

--- a/src/main/java/datadog/compiler/AnnotationsInjectingClassVisitor.java
+++ b/src/main/java/datadog/compiler/AnnotationsInjectingClassVisitor.java
@@ -67,7 +67,7 @@ public class AnnotationsInjectingClassVisitor extends TreeScanner<Void, Void> {
             classDeclaration.mods.annotations = classDeclaration.mods.annotations.prepend(sourcePathAnnotation);
         }
 
-        if (!sourceLinesDetected) {
+        if (!sourceLinesAnnotationDisabled && !sourceLinesDetected) {
             JCTree.JCModifiers modifiers = classDeclaration.getModifiers();
 
             int startPosition = modifiers.getStartPosition();

--- a/src/main/java/datadog/compiler/AnnotationsInjectingClassVisitor.java
+++ b/src/main/java/datadog/compiler/AnnotationsInjectingClassVisitor.java
@@ -80,20 +80,7 @@ public class AnnotationsInjectingClassVisitor extends TreeScanner<Void, Void> {
                 return super.visitClass(node, aVoid);
             }
 
-            int startLine = (int) lineMap.getLineNumber(startPosition);
-            int endLine = (int) lineMap.getLineNumber(endPosition);
-
-            Name startName = names.fromString("start");
-            JCTree.JCIdent startIdent = maker.Ident(startName);
-            JCTree.JCLiteral startLiteral = maker.Literal(startLine);
-            JCTree.JCAssign startAssign = maker.Assign(startIdent, startLiteral);
-
-            Name endName = names.fromString("end");
-            JCTree.JCIdent endIdent = maker.Ident(endName);
-            JCTree.JCLiteral endLiteral = maker.Literal(endLine);
-            JCTree.JCAssign endAssign = maker.Assign(endIdent, endLiteral);
-
-            JCTree.JCAnnotation sourceLinesAnnotation = annotation(maker, sourceLinesAnnotationType, startAssign, endAssign);
+            JCTree.JCAnnotation sourceLinesAnnotation = sourceLinesAnnotation(startPosition, endPosition);
             classDeclaration.mods.annotations = classDeclaration.mods.annotations.prepend(sourceLinesAnnotation);
         }
 
@@ -130,24 +117,28 @@ public class AnnotationsInjectingClassVisitor extends TreeScanner<Void, Void> {
                     }
                 }
 
-                int startLine = (int) lineMap.getLineNumber(startPosition);
-                int endLine = (int) lineMap.getLineNumber(endPosition);
-
-                Name startName = names.fromString("start");
-                JCTree.JCIdent startIdent = maker.Ident(startName);
-                JCTree.JCLiteral startLiteral = maker.Literal(startLine);
-                JCTree.JCAssign startAssign = maker.Assign(startIdent, startLiteral);
-
-                Name endName = names.fromString("end");
-                JCTree.JCIdent endIdent = maker.Ident(endName);
-                JCTree.JCLiteral endLiteral = maker.Literal(endLine);
-                JCTree.JCAssign endAssign = maker.Assign(endIdent, endLiteral);
-
-                JCTree.JCAnnotation sourceLinesAnnotation = annotation(maker, sourceLinesAnnotationType, startAssign, endAssign);
+                JCTree.JCAnnotation sourceLinesAnnotation = sourceLinesAnnotation(startPosition, endPosition);
                 methodDecl.mods.annotations = methodDecl.mods.annotations.prepend(sourceLinesAnnotation);
             }
         }
         return super.visitMethod(node, aVoid);
+    }
+
+    private JCTree.JCAnnotation sourceLinesAnnotation(int startPosition, int endPosition) {
+        int startLine = (int) lineMap.getLineNumber(startPosition);
+        int endLine = (int) lineMap.getLineNumber(endPosition);
+
+        Name startName = names.fromString("start");
+        JCTree.JCIdent startIdent = maker.Ident(startName);
+        JCTree.JCLiteral startLiteral = maker.Literal(startLine);
+        JCTree.JCAssign startAssign = maker.Assign(startIdent, startLiteral);
+
+        Name endName = names.fromString("end");
+        JCTree.JCIdent endIdent = maker.Ident(endName);
+        JCTree.JCLiteral endLiteral = maker.Literal(endLine);
+        JCTree.JCAssign endAssign = maker.Assign(endIdent, endLiteral);
+
+        return annotation(maker, sourceLinesAnnotationType, startAssign, endAssign);
     }
 
     private static JCTree.JCAnnotation annotation(TreeMaker maker, JCTree type, JCTree.JCExpression... arguments) {

--- a/src/main/java/datadog/compiler/DatadogCompilerPlugin.java
+++ b/src/main/java/datadog/compiler/DatadogCompilerPlugin.java
@@ -10,7 +10,7 @@ import java.util.Collection;
 
 public class DatadogCompilerPlugin implements Plugin {
 
-    static final String DISABLE_METHOD_ANNOTATION = "disableMethodAnnotation";
+    static final String DISABLE_SOURCE_LINES_ANNOTATION = "disableSourceLinesAnnotation";
 
     static {
         CompilerModuleOpener.setup();
@@ -30,8 +30,8 @@ public class DatadogCompilerPlugin implements Plugin {
             Context context = basicJavacTask.getContext();
 
             Collection<String> arguments = Arrays.asList(strings);
-            boolean methodAnnotationDisabled = arguments.contains(DISABLE_METHOD_ANNOTATION);
-            task.addTaskListener(new DatadogTaskListener(basicJavacTask, methodAnnotationDisabled));
+            boolean sourceLinesAnnotationDisabled = arguments.contains(DISABLE_SOURCE_LINES_ANNOTATION);
+            task.addTaskListener(new DatadogTaskListener(basicJavacTask, sourceLinesAnnotationDisabled));
 
             Log.instance(context).printRawLines(Log.WriterKind.NOTICE, NAME + " initialized");
         }

--- a/src/main/java/datadog/compiler/DatadogTaskListener.java
+++ b/src/main/java/datadog/compiler/DatadogTaskListener.java
@@ -20,11 +20,11 @@ import javax.tools.JavaFileObject;
 
 final class DatadogTaskListener implements TaskListener {
     private final BasicJavacTask basicJavacTask;
-    private final boolean methodAnnotationDisabled;
+    private final boolean sourceLinesAnnotationDisabled;
 
-    DatadogTaskListener(BasicJavacTask basicJavacTask, boolean methodAnnotationDisabled) {
+    DatadogTaskListener(BasicJavacTask basicJavacTask, boolean sourceLinesAnnotationDisabled) {
         this.basicJavacTask = basicJavacTask;
-        this.methodAnnotationDisabled = methodAnnotationDisabled;
+        this.sourceLinesAnnotationDisabled = sourceLinesAnnotationDisabled;
     }
 
     @Override
@@ -54,7 +54,7 @@ final class DatadogTaskListener implements TaskListener {
             JCTree.JCExpression sourcePathAnnotationType = select(maker, names, "datadog", "compiler", "annotations", "SourcePath");
             JCTree.JCAnnotation sourcePathAnnotation = annotation(maker, sourcePathAnnotationType, maker.Literal(sourcePath.toString()));
 
-            JCTree.JCExpression methodLinesAnnotationType = select(maker, names, "datadog", "compiler", "annotations", "MethodLines");
+            JCTree.JCExpression sourceLinesAnnotationType = select(maker, names, "datadog", "compiler", "annotations", "SourceLines");
 
             CompilationUnitTree compilationUnit = e.getCompilationUnit();
             LineMap lineMap = compilationUnit.getLineMap();
@@ -67,7 +67,7 @@ final class DatadogTaskListener implements TaskListener {
             }
 
             AnnotationsInjectingClassVisitor treeVisitor = new AnnotationsInjectingClassVisitor(
-                    maker, names, sourcePathAnnotation, methodLinesAnnotationType, methodAnnotationDisabled, lineMap, endPositions);
+                    maker, names, sourcePathAnnotation, sourceLinesAnnotationType, sourceLinesAnnotationDisabled, lineMap, endPositions);
             compilationUnit.accept(treeVisitor, null);
 
         } catch (Throwable t) {

--- a/src/test/java/datadog/compiler/DatadogCompilerPluginTest.java
+++ b/src/test/java/datadog/compiler/DatadogCompilerPluginTest.java
@@ -175,7 +175,7 @@ public class DatadogCompilerPluginTest {
 
     private static Stream<Arguments> classLinesInjectionArguments() {
         return Stream.of(
-                Arguments.of("datadog/compiler/Test.java", "datadog.compiler.Test", 3, 103),
+                Arguments.of("datadog/compiler/Test.java", "datadog.compiler.Test", 3, 107),
                 Arguments.of("datadog/compiler/Test.java", "datadog.compiler.Test$1", CompilerUtils.LINE_UNKNOWN, CompilerUtils.LINE_UNKNOWN), // lines unknown for anonymous class
                 Arguments.of("datadog/compiler/Test.java", "datadog.compiler.Test$InnerClass", 62, 62),
                 Arguments.of("datadog/compiler/Test.java", "datadog.compiler.Test$SplitDefinitionClass", 69, 73),
@@ -184,7 +184,8 @@ public class DatadogCompilerPluginTest {
                 Arguments.of("datadog/compiler/Test.java", "datadog.compiler.Test$StaticFinalClass", 83, 85),
                 Arguments.of("datadog/compiler/Test.java", "datadog.compiler.Test$AnnotatedClass", 87, 90),
                 Arguments.of("datadog/compiler/Test.java", "datadog.compiler.Test$CommentedClass", 96, 98), // we cannot establish correspondence between the class and the comment, so only actual class lines are considered here
-                Arguments.of("datadog/compiler/Test.java", "datadog.compiler.Test$TestInterface", 100, 102)
+                Arguments.of("datadog/compiler/Test.java", "datadog.compiler.Test$TestInterface", 100, 102),
+                Arguments.of("datadog/compiler/Test.java", "datadog.compiler.Test$TestEnum", 104, 106)
         );
     }
 

--- a/src/test/java/datadog/compiler/DatadogCompilerPluginTest.java
+++ b/src/test/java/datadog/compiler/DatadogCompilerPluginTest.java
@@ -175,7 +175,7 @@ public class DatadogCompilerPluginTest {
 
     private static Stream<Arguments> classLinesInjectionArguments() {
         return Stream.of(
-                Arguments.of("datadog/compiler/Test.java", "datadog.compiler.Test", 3, 99),
+                Arguments.of("datadog/compiler/Test.java", "datadog.compiler.Test", 3, 103),
                 Arguments.of("datadog/compiler/Test.java", "datadog.compiler.Test$1", CompilerUtils.LINE_UNKNOWN, CompilerUtils.LINE_UNKNOWN), // lines unknown for anonymous class
                 Arguments.of("datadog/compiler/Test.java", "datadog.compiler.Test$InnerClass", 62, 62),
                 Arguments.of("datadog/compiler/Test.java", "datadog.compiler.Test$SplitDefinitionClass", 69, 73),
@@ -183,7 +183,8 @@ public class DatadogCompilerPluginTest {
                 Arguments.of("datadog/compiler/Test.java", "datadog.compiler.Test$DefaultClass", 79, 81),
                 Arguments.of("datadog/compiler/Test.java", "datadog.compiler.Test$StaticFinalClass", 83, 85),
                 Arguments.of("datadog/compiler/Test.java", "datadog.compiler.Test$AnnotatedClass", 87, 90),
-                Arguments.of("datadog/compiler/Test.java", "datadog.compiler.Test$CommentedClass", 96, 98) // we cannot establish correspondence between the class and the comment, so only actual class lines are considered here
+                Arguments.of("datadog/compiler/Test.java", "datadog.compiler.Test$CommentedClass", 96, 98), // we cannot establish correspondence between the class and the comment, so only actual class lines are considered here
+                Arguments.of("datadog/compiler/Test.java", "datadog.compiler.Test$TestInterface", 100, 102)
         );
     }
 

--- a/src/test/resources/datadog/compiler/Test.java
+++ b/src/test/resources/datadog/compiler/Test.java
@@ -69,24 +69,24 @@ public abstract class Test {
     public
     class
     SplitDefinitionClass {
-        // no op
+        // empty class
     }
 
     private class PrivateClass {
-        // no op
+        // empty class
     }
 
     class DefaultClass {
-        // no op
+        // empty class
     }
 
     public static final class StaticFinalClass {
-        // no op
+        // empty class
     }
 
     @Deprecated
     public class AnnotatedClass {
-        // no op
+        // empty class
     }
 
     /**
@@ -94,6 +94,10 @@ public abstract class Test {
      * comment
      */
     public class CommentedClass {
-        // no op
+        // empty class
+    }
+
+    public interface TestInterface {
+        // empty interface
     }
 }

--- a/src/test/resources/datadog/compiler/Test.java
+++ b/src/test/resources/datadog/compiler/Test.java
@@ -100,4 +100,8 @@ public abstract class Test {
     public interface TestInterface {
         // empty interface
     }
+
+    public enum TestEnum {
+        // empty enum
+    }
 }

--- a/src/test/resources/datadog/compiler/Test.java
+++ b/src/test/resources/datadog/compiler/Test.java
@@ -65,4 +65,35 @@ public abstract class Test {
     public Test() {
         // no op constructor
     }
+
+    public
+    class
+    SplitDefinitionClass {
+        // no op
+    }
+
+    private class PrivateClass {
+        // no op
+    }
+
+    class DefaultClass {
+        // no op
+    }
+
+    public static final class StaticFinalClass {
+        // no op
+    }
+
+    @Deprecated
+    public class AnnotatedClass {
+        // no op
+    }
+
+    /**
+     * Multi line
+     * comment
+     */
+    public class CommentedClass {
+        // no op
+    }
 }

--- a/src/test/resources/datadog/compiler/TestAnnotated.java
+++ b/src/test/resources/datadog/compiler/TestAnnotated.java
@@ -1,12 +1,13 @@
 package datadog.compiler;
 
-import datadog.compiler.annotations.MethodLines;
+import datadog.compiler.annotations.SourceLines;
 import datadog.compiler.annotations.SourcePath;
 
 @SourcePath("the-source-path")
+@SourceLines(start = 1, end = 2)
 public class TestAnnotated {
 
-    @MethodLines(start = 1, end = 2)
+    @SourceLines(start = 1, end = 2)
     public void annotatedMethod() {
         // no op
     }


### PR DESCRIPTION
# What Does This Do

- Refactors the old `MethodLines` annotation into a more general `SourceLines` annotation
- Allows annotating classes, interfaces and enums with source lines data

# Motivation

In order to display source code for other java structures such as classes in Datadog products the plugin needs to annotate them to provide the source lines information.

# Additional Notes
