### PR TITLE
Bump burningwave.core dependency to support JDK 24

### DIFF
--- a/.github/workflows/dd-javac-plugin-tests.yaml
+++ b/.github/workflows/dd-javac-plugin-tests.yaml
@@ -75,3 +75,20 @@ jobs:
           distribution: "adopt"
       - name: run-unit-tests
         run: ./gradlew test -PtestJdkVersion=21
+
+  run-tests-jdk-24:
+    name: run-unit-tests-jdk-24
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: |
+            8
+            11
+            24
+          distribution: "adopt"
+      - name: run-unit-tests
+        run: ./gradlew test -PtestJdkVersion=24

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ apply from: "$rootDir/gradle/test.gradle"
 dependencies {
     compileOnly files(jvm8.toolsJar)
 
-    api "org.burningwave:core:12.65.1"
+    api "org.burningwave:core:12.66.2"
     api project(":dd-javac-plugin-client")
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.9.2"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
# What Does This Do

Bumps `org.burningwave:core` dependency to current latest version that supports JDK 24.
Adds JDK 24 tests to GHA workflow.
Bumps Gradle version to latest stable release.
