### PR TITLE
[Security] Harden supply chain dependencies

### DIFF
--- a/.github/workflows/dd-javac-plugin-tests.yaml
+++ b/.github/workflows/dd-javac-plugin-tests.yaml
@@ -10,12 +10,19 @@ on:
   workflow_dispatch:
 
 jobs:
+  validate-wrapper:
+    name: validate-gradle-wrapper
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: gradle/actions/wrapper-validation@ed408507eac070d1f99cc633dbcf757c94c7933a # v4.4.3
+
   run-tests-jdk-8:
     name: run-unit-tests-jdk-8
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Set up JDK
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
@@ -31,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Set up JDK
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
@@ -47,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Set up JDK
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
@@ -64,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Set up JDK
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
@@ -81,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Set up JDK
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,8 +18,10 @@ jobs:
             8
             11
           distribution: "adopt"
+      - name: Validate Gradle Wrapper
+        uses: gradle/actions/wrapper-validation@ed408507eac070d1f99cc633dbcf757c94c7933a # v4.4.3
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@48b5f213c81028ace310571dc5ec0fbbca0b2947 # v4
+        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4.4.3
       - name: Build with Gradle
         run: ./gradlew shadowJar
       - name: Release

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,6 +17,9 @@ deploy_to_sonatype:
   tags:
     - "docker-in-docker:amd64"
 
+  # TODO: openjdk:8 is deprecated and has been removed from Docker Hub.
+  # This image should be replaced (e.g. with eclipse-temurin:11-jdk)
+  # and pinned to a sha256 digest as part of the release process refactor.
   image: openjdk:8
 
   script:

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,11 @@ allprojects {
     }
 
     repositories {
-        mavenLocal()
+        mavenLocal {
+            content {
+                includeVersionByRegex(".*", ".*", ".*-SNAPSHOT")
+            }
+        }
         mavenCentral()
         gradlePluginPortal()
     }

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,10 @@ allprojects {
     apply plugin: "maven-publish"
     apply plugin: "signing"
 
+    dependencyLocking {
+        lockAllConfigurations()
+    }
+
     java {
         withJavadocJar()
         withSourcesJar()

--- a/dd-javac-plugin-client/gradle.lockfile
+++ b/dd-javac-plugin-client/gradle.lockfile
@@ -1,10 +1,11 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-org.apiguardian:apiguardian-api:1.1.2=testCompileClasspath,testRuntimeClasspath
+org.apiguardian:apiguardian-api:1.1.2=testCompileClasspath
 org.junit.jupiter:junit-jupiter-api:5.9.2=testCompileClasspath,testRuntimeClasspath
 org.junit.jupiter:junit-jupiter-engine:5.9.2=testRuntimeClasspath
 org.junit.platform:junit-platform-commons:1.9.2=testCompileClasspath,testRuntimeClasspath
 org.junit.platform:junit-platform-engine:1.9.2=testRuntimeClasspath
+org.junit:junit-bom:5.9.2=testCompileClasspath,testRuntimeClasspath
 org.opentest4j:opentest4j:1.2.0=testCompileClasspath,testRuntimeClasspath
 empty=annotationProcessor,compileClasspath,runtimeClasspath,testAnnotationProcessor

--- a/dd-javac-plugin-client/gradle.lockfile
+++ b/dd-javac-plugin-client/gradle.lockfile
@@ -1,0 +1,10 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+org.apiguardian:apiguardian-api:1.1.2=testCompileClasspath,testRuntimeClasspath
+org.junit.jupiter:junit-jupiter-api:5.9.2=testCompileClasspath,testRuntimeClasspath
+org.junit.jupiter:junit-jupiter-engine:5.9.2=testRuntimeClasspath
+org.junit.platform:junit-platform-commons:1.9.2=testCompileClasspath,testRuntimeClasspath
+org.junit.platform:junit-platform-engine:1.9.2=testRuntimeClasspath
+org.opentest4j:opentest4j:1.2.0=testCompileClasspath,testRuntimeClasspath
+empty=annotationProcessor,compileClasspath,runtimeClasspath,testAnnotationProcessor

--- a/gradle.lockfile
+++ b/gradle.lockfile
@@ -1,0 +1,15 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+commons-io:commons-io:2.14.0=testCompileClasspath,testRuntimeClasspath
+io.github.toolfactory:jvm-driver:9.8.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+org.apiguardian:apiguardian-api:1.1.2=testCompileClasspath,testRuntimeClasspath
+org.burningwave:core:12.66.2=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+org.burningwave:jvm-driver:8.19.1=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+org.junit.jupiter:junit-jupiter-api:5.9.2=testCompileClasspath,testRuntimeClasspath
+org.junit.jupiter:junit-jupiter-engine:5.9.2=testRuntimeClasspath
+org.junit.jupiter:junit-jupiter-params:5.9.2=testCompileClasspath,testRuntimeClasspath
+org.junit.platform:junit-platform-commons:1.9.2=testCompileClasspath,testRuntimeClasspath
+org.junit.platform:junit-platform-engine:1.9.2=testRuntimeClasspath
+org.opentest4j:opentest4j:1.2.0=testCompileClasspath,testRuntimeClasspath
+empty=annotationProcessor,java11AnnotationProcessor,java11CompileClasspath,java11RuntimeClasspath,shadow,testAnnotationProcessor

--- a/gradle.lockfile
+++ b/gradle.lockfile
@@ -3,7 +3,7 @@
 # This file is expected to be part of source control.
 commons-io:commons-io:2.14.0=testCompileClasspath,testRuntimeClasspath
 io.github.toolfactory:jvm-driver:9.8.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-org.apiguardian:apiguardian-api:1.1.2=testCompileClasspath,testRuntimeClasspath
+org.apiguardian:apiguardian-api:1.1.2=testCompileClasspath
 org.burningwave:core:12.66.2=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 org.burningwave:jvm-driver:8.19.1=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 org.junit.jupiter:junit-jupiter-api:5.9.2=testCompileClasspath,testRuntimeClasspath
@@ -11,5 +11,6 @@ org.junit.jupiter:junit-jupiter-engine:5.9.2=testRuntimeClasspath
 org.junit.jupiter:junit-jupiter-params:5.9.2=testCompileClasspath,testRuntimeClasspath
 org.junit.platform:junit-platform-commons:1.9.2=testCompileClasspath,testRuntimeClasspath
 org.junit.platform:junit-platform-engine:1.9.2=testRuntimeClasspath
+org.junit:junit-bom:5.9.2=testCompileClasspath,testRuntimeClasspath
 org.opentest4j:opentest4j:1.2.0=testCompileClasspath,testRuntimeClasspath
 empty=annotationProcessor,java11AnnotationProcessor,java11CompileClasspath,java11RuntimeClasspath,shadow,testAnnotationProcessor

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
+distributionSha256Sum=7197a12f450794931532469d4ff21a59ea2c1cd59a3ec3f89c035c3c420a6999
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary
- Add Gradle dependency lockfiles (`gradle.lockfile`) to pin all transitive dependency versions and enable `lockAllConfigurations()` across all subprojects
- Restrict `mavenLocal()` to SNAPSHOT versions only, ensuring releases always resolve from Maven Central with full Gradle Module Metadata (fixes inconsistent lockfile resolution between local and CI)
- Add `distributionSha256Sum` to `gradle-wrapper.properties` for Gradle distribution integrity verification
- Add `gradle/actions/wrapper-validation` CI step to both GHA workflows (tests + release)
- Update `actions/checkout` from v2 to v4 in test workflow (was 4 major versions behind)
- Pin `gradle/actions/setup-gradle` to commit SHA with exact version comment (`v4.4.3` instead of floating `v4`)
- Add TODO for deprecated `openjdk:8` image in GitLab CI (tag removed from Docker Hub, needs migration as part of release process refactor)

## What's NOT changed (and why)
- **GitLab CI `openjdk:8` image**: deprecated and removed from Docker Hub — requires migration to e.g. `eclipse-temurin:11-jdk`, deferred to release process refactor
- **GitLab CI `apt`/`pip` installs**: transient CI tools, not part of the build artifact supply chain
- **Internal ECR image (`gpg:1`)**: internal image, low risk

## Test plan
- [x] `./gradlew build` passes locally with dependency locking enabled
- [x] Verify GHA test workflow runs successfully with updated `actions/checkout` v4
- [x] Verify GHA wrapper-validation job passes
- [ ] Verify release workflow is not affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)